### PR TITLE
chore: fix sample.env

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -1,3 +1,3 @@
-F0_BIND="127.0.0.1:3000"
+FO_BIND="127.0.0.1:3000"
 FO_DATABASE="sqlite://test_db.sqlite"
-FM_ADMIN_AUTH="foobar"
+FO_ADMIN_AUTH="foobar"


### PR DESCRIPTION
All prefixes should be `FO` for "FEDIMINT OBSERVER"

I was now able to run the following to get it working:

```
cp sample.env .env

// creates empty sqlite db file ... without this it was complaining that it couldn't open db
sqlite3 test_db.sqlite "VACUUM;"

cargo run
```