### PR TITLE
feat: optionally allow cors for config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,6 +1014,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokio",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3524,6 +3525,22 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.5.0",
+ "bytes",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,27 @@ axum = { version = "0.7.5", features = ["json"] }
 axum-auth = "0.7.0"
 csv = "1.3.0"
 dotenv = "0.15.0"
-esplora-client = { version = "0.7.0", default-features = false, features = ["async-https-rustls"] }
+esplora-client = { version = "0.7.0", default-features = false, features = [
+  "async-https-rustls",
+] }
 futures = "0.3.30"
 hex = "0.4.3"
-reqwest = { version = "0.12.2", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12.2", default-features = false, features = [
+  "json",
+  "rustls-tls",
+] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
-sqlx = {version = "0.7.4", default-features = false, features = ["json", "runtime-tokio", "tls-rustls", "any", "sqlite", "postgres", "macros"]}
-tokio = { version = "1.37.0", features = ["full"]}
+sqlx = { version = "0.7.4", default-features = false, features = [
+  "json",
+  "runtime-tokio",
+  "tls-rustls",
+  "any",
+  "sqlite",
+  "postgres",
+  "macros",
+] }
+tokio = { version = "1.37.0", features = ["full"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tower-http = { version = "0.5.2", features = ["cors"] }


### PR DESCRIPTION
Bitcoinmints sends requests from the browser so need to allow cors for these methods. If you've got a preferred way to do it lmk we can use that, this just optionally lets you allow cors for the config methods which is all I'm using for bitcoinmints