### PR TITLE
feat: add sqlite to postgres migration script

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,8 @@
         devShells = flakeboxLib.mkShells {
           nativeBuildInputs = [
             pkgs.postgresql
+            # sqlite is used only for creating the dump file for migrating existing instances
+            pkgs.sqlite
           ] ++ lib.optionals stdenv.isDarwin [
             pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
           ];

--- a/scripts/migrate_sqlite_to_postgres.sh
+++ b/scripts/migrate_sqlite_to_postgres.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Usage:
+# $ ./scripts/migrate_sqlite_to_postgres.sh <sqlite_db_file>
+
+set -euo pipefail
+
+if [ -z "$1" ]; then
+  echo "Must pass sqlite db file as arg"
+  exit 1
+fi
+
+SQLITE_DB_FILE="$1"
+DUMP_FILE=sqlite_db_dump.sql
+
+pg="psql --host=$PGHOST -p $PGPORT --dbname=${PGDATABASE}"
+
+if pg_isready > /dev/null 2>&1; then
+  output=$($pg -c '\d' 2>&1)
+  if [[ "$output" == *"Did not find any relations."* ]]; then
+    echo "No relations found in postgres db, starting migration"
+  else
+    echo "Relations found in postgres db"
+    echo "Migration must run using an empty postgres instance"
+    exit 1
+  fi
+else
+  echo "Must start an empty instance of postgres with just pg_start"
+  exit 1
+fi
+
+echo "Dumping sqlite db file"
+sqlite3 "$SQLITE_DB_FILE" .dump > "$DUMP_FILE"
+echo "Finished sqlite dump"
+
+echo "Parsing dump file, converting syntax to postgres"
+
+sed -i \
+  -e 's/PRAGMA foreign_keys=OFF;//g' \
+  -e 's/BLOB/BYTEA/g' \
+  -e "s/X'\([^']*\)'/'\\\x\1'/g" \
+  -e 's/amount_msat INTEGER/amount_msat BIGINT/g' \
+  -e 's/timestamp INTEGER/timestamp TIMESTAMP/g' \
+  -e 's/FOREIGN KEY (federation_id, txid) REFERENCES transactions(federation_id, txid),/FOREIGN KEY (federation_id, txid) REFERENCES transactions(federation_id, txid)/g' \
+  -e 's/FOREIGN KEY (federation_id, ln_contract_id) REFERENCES ln_contracts(federation_id, contract_id)/--/g' \
+  -e "s/VALUES(\([0-9]*\),\s*\([0-9]*\))/VALUES(\1, to_timestamp(\2))/g" \
+  "$DUMP_FILE"
+
+echo "Finished parsing dump file"
+
+echo "Importing parsed dump file into postgres"
+echo "This may take several minutes..."
+time $pg < "$DUMP_FILE" > /dev/null
+echo "Finished importing dump file into postgres, cleaning up"
+rm  "$DUMP_FILE"


### PR DESCRIPTION
> I don't think building a migration in code makes sense for the two instances or so that exist. For my instance I'll probably just re-sync. If that's not possible for others I'd recommend dumping the SQL and transforming it into postgres-compatible SQL using `sed`

https://github.com/elsirion/fedimint-observer/pull/20#issuecomment-2262741019

Some of the federations in my existing instance are no longer running, so re-syncing wasn't an option 🙂 

No worries if we don't want to merge and maintain, but this will at least be a reference if anyone else wants/needs to migrate.

After initializing a new postgres instance with `just pg_start`

```
./scripts/migrate_sqlite_to_postgres.sh <sqlite_db_file>
```

After migrating I've been able to successfully run `fedimint-observer` using latest `master` and haven't bumped into any issues (running for ~1 day).