### PR TITLE
chore: add backup and restore scripts and just aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test_db.sqlite
 fedimint_observer.db
 .direnv
 .pg_dev
+/db_backups

--- a/justfile.fmo.just
+++ b/justfile.fmo.just
@@ -3,3 +3,9 @@ pg_start:
 
 pg_stop:
   ./scripts/pg_dev/stop.sh
+
+pg_backup:
+  ./scripts/pg_dev/backup.sh
+
+pg_restore BACKUP_FILE:
+  ./scripts/pg_dev/restore.sh {{BACKUP_FILE}}

--- a/scripts/pg_dev/backup.sh
+++ b/scripts/pg_dev/backup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mkdir -p db_backups
+timestamp=$(date +'%Y-%m-%d_%H%M')
+pg_dump --host="$PGHOST" -p "$PGPORT" --dbname="${PGDATABASE}" > "db_backups/${timestamp}_backup.sql"

--- a/scripts/pg_dev/restore.sh
+++ b/scripts/pg_dev/restore.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ -z "$1" ]; then
+  echo "Must pass backup file as arg"
+  exit 1
+fi
+
+BACKUP_FILE="$1"
+
+pg="psql --host=$PGHOST -p $PGPORT --dbname=${PGDATABASE}"
+
+if pg_isready > /dev/null 2>&1; then
+  output=$($pg -c '\d' 2>&1)
+  if [[ "$output" == *"Did not find any relations."* ]]; then
+    echo "No relations found in postgres db, restoring"
+  else
+    echo "Relations found in postgres db"
+    echo "Restore must run using an empty postgres instance"
+    exit 1
+  fi
+else
+  echo "Must start an empty instance of postgres with just pg_start"
+  exit 1
+fi
+
+time $pg < "$BACKUP_FILE" > /dev/null
+echo "Restore complete"


### PR DESCRIPTION
Using a simple plaintext (sql) dump format instead of custom, directory, or tar formats. Happy to switch the format if we'd prefer a different one.

```bash
nix@1235afff2e46:~/fedimint-observer$ just pg_backup
./scripts/pg_dev/backup.sh
nix@1235afff2e46:~/fedimint-observer$ just pg_stop && rm -rf .pg_dev/ && just pg_start
...
nix@1235afff2e46:~/fedimint-observer$ just pg_restore 2024-08-10_2307_backup.sql
./scripts/pg_dev/restore.sh 2024-08-10_2307_backup.sql
No relations found in postgres db, restoring

real    0m32.478s
user    0m0.545s
sys     0m0.613s
Restore complete
```