### PR TITLE
fix: run a complete migration for empty database

### DIFF
--- a/src/federation/observer.rs
+++ b/src/federation/observer.rs
@@ -87,15 +87,22 @@ impl FederationObserver {
                 max_version INTEGER;
             BEGIN
                 IF EXISTS (
-                    SELECT 1 
-                    FROM pg_catalog.pg_tables 
-                    WHERE schemaname = 'public' 
+                    SELECT 1
+                    FROM pg_catalog.pg_tables
+                    WHERE schemaname = current_schema()
                     AND tablename = 'schema_version'
                 ) THEN
                     SELECT COALESCE(MAX(version), 0) INTO max_version
                     FROM schema_version;
-                ELSE
+                ELSIF EXISTS (
+                    SELECT 1
+                    FROM pg_catalog.pg_tables
+                    WHERE schemaname = current_schema()
+                    AND tablename = 'federations'
+                ) THEN
                     max_version := 0;
+                ELSE
+                    max_version := -1;
                 END IF;
 
                 RETURN max_version;


### PR DESCRIPTION
A empty new database will default to `0` schema version, so the first migration will not be executed. 
This PR addresses this by detecting whether the v0 schema is present by checking if the `federations` table exists.
If the table is found, it returns `0` as the schema version,  otherwise, it returns `-1` for a full database creation.

Also added the `current_schema()` in this same function, instead of the hardcoded `'public'`.