### PR TITLE
refactor: updated session_times view

### DIFF
--- a/fmo_server/schema/v5.sql
+++ b/fmo_server/schema/v5.sql
@@ -1,0 +1,84 @@
+-- Create the update session_times view
+BEGIN;
+INSERT INTO schema_version (version)
+VALUES (5);
+
+DROP MATERIALIZED VIEW IF EXISTS session_times;
+
+CREATE MATERIALIZED VIEW session_times AS
+WITH proposer_votes AS (
+    SELECT
+        federation_id,
+        session_index,
+        proposer,
+        MAX(height_vote) AS proposer_height
+    FROM block_height_votes
+    GROUP BY federation_id, session_index, proposer
+),
+
+session_proposer_heights AS (
+    SELECT
+        federation_id,
+        session_index,
+        proposer_height,
+        COUNT(*) AS vote_cnt
+    FROM proposer_votes
+    GROUP BY federation_id, session_index, proposer_height
+),
+
+session_heights AS (
+    SELECT
+        federation_id,
+        session_index,
+        proposer_height AS block_height,
+        vote_cnt,
+        ROW_NUMBER()
+            OVER (
+                PARTITION BY federation_id, session_index ORDER BY vote_cnt DESC
+            )
+        AS rn
+    FROM session_proposer_heights
+),
+
+session_times AS (
+    SELECT
+        sh.federation_id,
+        sh.session_index,
+        sh.block_height,
+        bt.timestamp,
+        sh.vote_cnt
+    FROM session_heights AS sh
+    LEFT JOIN
+        block_times AS bt
+        ON sh.block_height = bt.block_height
+    WHERE sh.rn = 1
+)
+
+SELECT
+    s.federation_id,
+    s.session_index,
+    MAX(st.timestamp)
+        OVER (
+            PARTITION BY s.federation_id
+            ORDER BY
+                s.session_index
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        )
+    AS estimated_session_timestamp
+FROM sessions AS s
+LEFT JOIN
+    session_times AS st
+    ON s.federation_id = st.federation_id AND s.session_index = st.session_index
+ORDER BY s.federation_id, s.session_index;
+
+CREATE INDEX session_times_federation_id_idx ON session_times (federation_id);
+
+CREATE UNIQUE INDEX session_times_federation_id_session_index_idx ON session_times (
+    federation_id, session_index
+);
+
+CREATE INDEX session_times_federation_id_estimated_session_timestamp_idx ON session_times (
+    federation_id, estimated_session_timestamp
+);
+
+COMMIT;

--- a/fmo_server/src/federation/observer.rs
+++ b/fmo_server/src/federation/observer.rs
@@ -164,6 +164,10 @@ impl FederationObserver {
                 4,
                 include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/schema/v4.sql")),
             ),
+            (
+                5,
+                include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/schema/v5.sql")),
+            ),
         ];
 
         for (version, migration) in migration_map.iter() {


### PR DESCRIPTION
This new session_times query has an output slightly different than the original. This affects 0.4% of all sessions (4290 out of 1006724), and only in 0.08% of them the difference is larger than 1 minute.
The difference is because my version chooses the block_height with most votes.

For example in federation 5BC553E651E52177657255A5BA02155F4177B0B52CD4DD12757B7B9AA84AD032, session 46466, there were 4 votes for height 849214 and one for 849215. The original session_times would choose the later, but the correct should be 849214 (most votes).

Also, the new query runs twice as fast.
After fetching all sessions for one federation, I got this results:
 * original query ran in 392 ms ± 8.22
 * new query ran in 174 ms ± 6.14


This change was tested locally. Had trouble building the fmo_frontend, but running only fmo_server was enough to make sure nothing was breaking.

