### PR TITLE
feat: mempool url parametrized as env var

### DIFF
--- a/fmo_server/src/main.rs
+++ b/fmo_server/src/main.rs
@@ -57,6 +57,7 @@ async fn main() -> anyhow::Result<()> {
             federation_observer: FederationObserver::new(
                 &dotenv::var("FO_DATABASE").context("No FO_DATABASE provided")?,
                 &dotenv::var("FO_ADMIN_AUTH").context("No FO_ADMIN_AUTH provided")?,
+                &dotenv::var("FO_MEMPOOL_URL").context("No FO_MEMPOOL_URL provided")?,
             )
             .await?,
         });

--- a/sample.env
+++ b/sample.env
@@ -3,3 +3,4 @@ FO_BIND="127.0.0.1:3000"
 # provide as a query param (`?host=`) or percent-encode (`%2F`)
 FO_DATABASE="postgres://${PGUSER}@/${PGDATABASE}?host=${PGHOST}&port=${PGPORT}"
 FO_ADMIN_AUTH="foobar"
+FO_MEMPOOL_URL="https://mempool.space/api"


### PR DESCRIPTION
mempool.space sometimes blocks IPs that are bothering them too much.
Instead of harcoding their URL when instantiating esplora client, the URL now comes from a parameter defined in the .env file, this way it's easier to swap to another provider with compatible API like blockstream.info or others.