### PR TITLE
feat: new route to backfill federation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "fmo_server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/fmo_server/Cargo.toml
+++ b/fmo_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fmo_server"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Adds a new route `/:federation_id/backfill` that is a POST, with authentication required.
The federation_id goes directly in the URL, and optional session_start and session_end parameters can be passed in the POST body (as JSON).

Currently, the request will only return when the backfill is complete. This is not ideal, should spawn a task_group. We can leave at as is and accept the technical dept or, I can work on it. The positive side of it is that it kind of forces the user to only process in small batches (~5k sessions is reasonable).

Any other suggestions on improving this feature will be appreciated.

Oh, also bumped fmo_server version from "0.1.0" to "0.2.0"