### PR TITLE
Publish latest and master Docker image tags

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -41,4 +41,9 @@ jobs:
         env:
           IMAGE_TAG: ${{ github.sha }}
         run: |-
-          nix_tag=${{ env.fedimint_observer_container_tag }} && hub_tag="$REGISTRY/$REPOSITORY:$IMAGE_TAG" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
+          nix_tag="${{ env.fedimint_observer_container_tag }}"
+          for tag in "$IMAGE_TAG" "latest" "master"; do
+            hub_tag="$REGISTRY/$REPOSITORY:$tag"
+            docker tag "$nix_tag" "$hub_tag"
+            docker push "$hub_tag"
+          done


### PR DESCRIPTION
## Summary
- Update the GHCR publish workflow to push `latest` and `master` tags in addition to the commit SHA tag
- This matches what `docker-compose.yml` already expects (`ghcr.io/elsirion/fedimint-observer:latest`)

## Test plan
- [ ] Verify the workflow runs on next push to master and publishes all three tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)